### PR TITLE
Changing reward delivery values post caliberation

### DIFF
--- a/Experiment_Launcher_code/ExperimentManager.py
+++ b/Experiment_Launcher_code/ExperimentManager.py
@@ -92,18 +92,19 @@ class ExperimentManager:
 
     def on_release(self, key):
         print(f"Key released: {key}")
-
+    """""
     def start_state_timer(self, state):
-        """ Start the timer for a given state """
+      
         self.state_start_times[state] = time.time()
 
     def get_state_duration(self, state):
-        """ Calculate the duration spent in a given state """
+       
         return time.time() - self.state_start_times.get(state, time.time())
+    """
     def StateActivity(self, state, mouse1, mouse2):
         if state is not None:
-            duration = self.get_state_duration(state)
-            self.event_logger.log_event_data(self.numcompletedtrial,state,duration)
+
+            self.event_logger.log_event_data(self.numcompletedtrial,state,time.time())
 
         if state == States.Start:
 

--- a/Experiment_Launcher_code/ExperimentManager.py
+++ b/Experiment_Launcher_code/ExperimentManager.py
@@ -55,11 +55,11 @@ class ExperimentManager:
         self.opponent_type = ""  ##for the logger
 
         # Set default reward and punishment times
-        self.reward_time = 0.02
+        self.reward_time = 0.2
         self.sucker_time = 0
-        self.temptation_time = 0.04
-        self.punishment_time = 0.01
-        self.center_reward_time = 0.09
+        self.temptation_time = 0.4
+        self.punishment_time = 0.1
+        self.center_reward_time = 0.02
 
         # initialize experiment control variables
         self.numcompletedtrial = 0
@@ -142,8 +142,8 @@ class ExperimentManager:
             # Actions for M1CM2C state
             self.mouse_choice = "C"
             self.opponent_choice = "C"
-            self.mouse_reward = "0.03"
-            self.opponent_reward = "0.03"
+            self.mouse_reward = "0.012"
+            self.opponent_reward = "0.012"
             self.mouse_center_reward="0.0"
             self.opponent_center_reward = "0.0"
             self.cc_cnt += 1
@@ -156,7 +156,7 @@ class ExperimentManager:
             self.mouse_choice = "C"
             self.opponent_choice = "D"
             self.mouse_reward = "0"
-            self.opponent_reward = "0.06"
+            self.opponent_reward = "0.024"
             self.mouse_center_reward = "0.0"
             self.opponent_center_reward = "0.0"
             self.cd_cnt += 1
@@ -168,7 +168,7 @@ class ExperimentManager:
             # Actions for M1DCM2C state
             self.mouse_choice = "D"
             self.opponent_choice = "C"
-            self.mouse_reward = "0.06"
+            self.mouse_reward = "0.024"
             self.opponent_reward = "0"
             self.mouse_center_reward = "0.0"
             self.opponent_center_reward = "0.0"
@@ -181,8 +181,8 @@ class ExperimentManager:
             # Actions for M1DM2D state
             self.mouse_choice = "D"
             self.opponent_choice = "D"
-            self.mouse_reward = "0.015"
-            self.opponent_reward = "0.015"
+            self.mouse_reward = "0.006"
+            self.opponent_reward = "0.006"
             self.mouse_center_reward = "0.0"
             self.opponent_center_reward = "0.0"
             self.dd_cnt += 1

--- a/Experiment_Launcher_code/experimentgui.py
+++ b/Experiment_Launcher_code/experimentgui.py
@@ -25,9 +25,9 @@ class ExperimentGUI:
         # Initialize entry variables
         self.experiment_name = tk.StringVar(value = "Experiment 1")
         self.comport_name = tk.StringVar(value = "COM11")
-        self.num_trials_var = tk.StringVar(value = "20")
-        self.return_time_var = tk.StringVar(value = "30")
-        self.decision_time_var = tk.StringVar(value = "30")
+        self.num_trials_var = tk.StringVar(value = "50")
+        self.return_time_var = tk.StringVar(value = "20")
+        self.decision_time_var = tk.StringVar(value = "20")
         self.mouse_id_var = tk.StringVar(value="1777")
         self.selected_opp = tk.StringVar(value = None)
         self.first_opponent_type = tk.StringVar(value = None)


### PR DESCRIPTION
changes to the 
-valve opening times 
-reward volumes that are logged
-default trial values in gui.

somehow these changes got overwritten in the most recent merge